### PR TITLE
Add MIDI device control and clock sync

### DIFF
--- a/src/components/ParameterPanel.astro
+++ b/src/components/ParameterPanel.astro
@@ -102,6 +102,19 @@
       <label for="cycle-beats-input" class="control-label">8ths/Cycle</label>
       <input type="number" id="cycle-beats-input" class="control-input" min="1" max="32" value="8">
     </div>
+
+    <div class="parameter-group">
+      <label for="midi-device-select" class="control-label">MIDI Device</label>
+      <select id="midi-device-select" class="control-select"></select>
+    </div>
+
+    <div class="parameter-group">
+      <label for="clock-source-select" class="control-label">Clock Source</label>
+      <select id="clock-source-select" class="control-select">
+        <option value="INTERNAL">Internal</option>
+        <option value="MIDI">MIDI</option>
+      </select>
+    </div>
   </div>
 </div>
 

--- a/src/lib/advanced-functions.ts
+++ b/src/lib/advanced-functions.ts
@@ -1,5 +1,6 @@
 import * as Tone from 'tone';
 import { EchoplexState, Loop, LoopFunction, LoopSettings, UndoAction } from './types';
+import { MidiController } from './midi-controller';
 
 /**
  * Advanced looper functions for the Digital Echo Plex
@@ -285,14 +286,24 @@ export class AdvancedLooperFunctions {
   /**
    * Implement synchronization with external clock
    */
-  syncToExternalClock(enabled: boolean): void {
+  syncToExternalClock(enabled: boolean, midi?: MidiController): void {
     if (enabled) {
-      // Enable external sync
       Tone.Transport.syncSource = 'midi';
+
+      if (midi) {
+        midi.onStart = () => this.audioEngine.startLoopPlayback();
+        midi.onStop = () => this.audioEngine.stopLoopPlayback();
+        midi.onTempo = (bpm: number) => this.setTempo(Math.round(bpm));
+      }
+
       console.log('Synced to external MIDI clock');
     } else {
-      // Use internal clock
       Tone.Transport.syncSource = 'transport';
+      if (midi) {
+        midi.onStart = undefined;
+        midi.onStop = undefined;
+        midi.onTempo = undefined;
+      }
       console.log('Using internal clock');
     }
   }

--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -96,7 +96,9 @@ export class EchoplexAudioEngine {
       feedback: 0.5,
       inputGain: 0.8,
       outputGain: 0.8,
-      mix: 0.5
+      mix: 0.5,
+      midiDeviceId: undefined,
+      clockSource: 'INTERNAL'
     };
   }
 
@@ -698,7 +700,11 @@ export class EchoplexAudioEngine {
     if (settings.mix !== undefined) {
       this.mixer.fade.value = settings.mix;
     }
-    
+
+    if (settings.tempo !== undefined) {
+      Tone.Transport.bpm.value = settings.tempo;
+    }
+
     console.log('Settings updated:', settings);
   }
 

--- a/src/lib/midi-controller.ts
+++ b/src/lib/midi-controller.ts
@@ -1,0 +1,147 @@
+import { EchoplexAudioEngine } from './audio-engine';
+import { AdvancedLooperFunctions } from './advanced-functions';
+import { LoopFunction } from './types';
+
+interface NoteMapping {
+  [note: number]: LoopFunction;
+}
+
+interface CCMapping {
+  [cc: number]: keyof Pick<ReturnType<EchoplexAudioEngine['getState']>['settings'],
+    'feedback' | 'inputGain' | 'outputGain' | 'mix'>;
+}
+
+export class MidiController {
+  private midi: MIDIAccess | null = null;
+  private input: MIDIInput | null = null;
+  private clockCount = 0;
+  private lastClock = 0;
+
+  public onTempo?: (bpm: number) => void;
+  public onStart?: () => void;
+  public onStop?: () => void;
+
+  constructor(
+    private engine: EchoplexAudioEngine,
+    private advanced: AdvancedLooperFunctions,
+    private noteMap: NoteMapping = {},
+    private ccMap: CCMapping = {}
+  ) {}
+
+  async init(): Promise<void> {
+    this.midi = await navigator.requestMIDIAccess();
+  }
+
+  getInputs(): MIDIInput[] {
+    return this.midi ? Array.from(this.midi.inputs.values()) : [];
+  }
+
+  setInput(id: string): void {
+    if (!this.midi) return;
+    if (this.input) {
+      this.input.removeEventListener('midimessage', this.handleMessage);
+    }
+    this.input = this.midi.inputs.get(id) || null;
+    if (this.input) {
+      this.input.addEventListener('midimessage', this.handleMessage);
+    }
+  }
+
+  private handleMessage = (e: WebMidi.MIDIMessageEvent) => {
+    const [status, d1, d2] = e.data;
+
+    if (status === 0xfa) {
+      this.onStart?.();
+      return;
+    }
+    if (status === 0xfc) {
+      this.onStop?.();
+      return;
+    }
+    if (status === 0xf8) {
+      this.handleClock();
+      return;
+    }
+
+    const cmd = status & 0xf0;
+    if (cmd === 0xb0) {
+      this.handleCC(d1, d2);
+    } else if (cmd === 0x90 && d2 > 0) {
+      this.handleNote(d1);
+    }
+  };
+
+  private handleClock(): void {
+    const now = performance.now();
+    if (this.clockCount === 0) {
+      this.lastClock = now;
+    }
+    this.clockCount++;
+    if (this.clockCount >= 24) {
+      const diff = now - this.lastClock;
+      const bpm = 60000 / diff;
+      this.onTempo?.(bpm);
+      this.clockCount = 0;
+      this.lastClock = now;
+    }
+  }
+
+  private handleCC(cc: number, value: number): void {
+    const param = this.ccMap[cc];
+    if (!param) return;
+    const scaled = value / 127;
+    const update: any = {};
+    update[param] = scaled;
+    this.engine.updateSettings(update);
+  }
+
+  private handleNote(note: number): void {
+    const func = this.noteMap[note];
+    if (func === undefined) return;
+    this.executeFunction(func);
+  }
+
+  private executeFunction(func: LoopFunction): void {
+    const state = this.engine.getState();
+    switch (func) {
+      case LoopFunction.RECORD:
+        if (state.isRecording) {
+          this.engine.stopRecording();
+        } else {
+          this.engine.startRecording();
+        }
+        break;
+      case LoopFunction.OVERDUB:
+        if (state.isOverdubbing) {
+          this.engine.stopOverdub();
+        } else {
+          this.engine.startOverdub();
+        }
+        break;
+      case LoopFunction.MUTE:
+        this.engine.toggleMute();
+        break;
+      case LoopFunction.REVERSE:
+        this.engine.reverseLoop();
+        break;
+      case LoopFunction.HALF_SPEED:
+        this.engine.toggleHalfSpeed();
+        break;
+      case LoopFunction.UNDO:
+        this.engine.undo();
+        break;
+      case LoopFunction.NEXT_LOOP:
+        this.engine.nextLoop();
+        break;
+      case LoopFunction.PREVIOUS_LOOP:
+        this.engine.previousLoop();
+        break;
+      case LoopFunction.RESET:
+        this.engine.resetLoop();
+        break;
+      default:
+        break;
+    }
+  }
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,8 @@ export interface LoopSettings {
   inputGain: number;
   outputGain: number;
   mix: number;
+  midiDeviceId?: string;
+  clockSource: 'INTERNAL' | 'MIDI';
 }
 
 export interface Loop {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,8 @@
 ---
 import { EchoplexAudioEngine } from '../lib/audio-engine';
+import { AdvancedLooperFunctions } from '../lib/advanced-functions';
+import { MidiController } from '../lib/midi-controller';
+import { LoopFunction } from '../lib/types';
 import WaveformDisplay from '../components/WaveformDisplay.astro';
 import ControlPanel from '../components/ControlPanel.astro';
 import TransportControls from '../components/TransportControls.astro';
@@ -54,6 +57,8 @@ import ParameterPanel from '../components/ParameterPanel.astro';
   <script>
     // Global variables
     let echoplexEngine = null;
+    let advancedFunctions = null;
+    let midiController = null;
     let audioContextStarted = false;
     
     // Power button initialization
@@ -82,6 +87,21 @@ import ParameterPanel from '../components/ParameterPanel.astro';
               // Create the engine
               window.echoplexEngine = new EchoplexAudioEngine();
               echoplexEngine = window.echoplexEngine;
+              advancedFunctions = new AdvancedLooperFunctions(echoplexEngine);
+              const noteMap = {
+                60: LoopFunction.RECORD,
+                61: LoopFunction.OVERDUB,
+                62: LoopFunction.MUTE,
+                63: LoopFunction.REVERSE
+              };
+              const ccMap = {
+                20: 'feedback',
+                21: 'inputGain',
+                22: 'outputGain',
+                23: 'mix'
+              } as any;
+              midiController = new MidiController(echoplexEngine, advancedFunctions, noteMap, ccMap);
+              await midiController.init();
               
               // Request microphone access
               powerStatus.textContent = 'Requesting microphone access...';
@@ -107,6 +127,7 @@ import ParameterPanel from '../components/ParameterPanel.astro';
             
             // Initialize UI components
             initializeUI();
+            populateMidiDevices();
             
           } catch (error) {
             // Handle initialization errors
@@ -295,9 +316,36 @@ import ParameterPanel from '../components/ParameterPanel.astro';
       // Interface mode select
       document.getElementById('interface-mode-select')?.addEventListener('change', (e) => {
         if (!echoplexEngine) return;
-        
+
         const value = (e.target as HTMLSelectElement).value as any;
         echoplexEngine.updateSettings({ interfaceMode: value });
+      });
+
+      document.getElementById('tempo-input')?.addEventListener('input', (e) => {
+        if (!echoplexEngine) return;
+        const value = parseFloat((e.target as HTMLInputElement).value);
+        echoplexEngine.updateSettings({ tempo: value });
+      });
+
+      document.getElementById('cycle-beats-input')?.addEventListener('input', (e) => {
+        if (!echoplexEngine) return;
+        const value = parseInt((e.target as HTMLInputElement).value, 10);
+        echoplexEngine.updateSettings({ cycleBeats: value });
+      });
+
+      document.getElementById('clock-source-select')?.addEventListener('change', (e) => {
+        if (!advancedFunctions || !midiController) return;
+        const value = (e.target as HTMLSelectElement).value as any;
+        echoplexEngine.updateSettings({ clockSource: value });
+        const useMidi = value === 'MIDI';
+        advancedFunctions.syncToExternalClock(useMidi, midiController);
+      });
+
+      document.getElementById('midi-device-select')?.addEventListener('change', (e) => {
+        if (!midiController) return;
+        const id = (e.target as HTMLSelectElement).value;
+        midiController.setInput(id);
+        echoplexEngine.updateSettings({ midiDeviceId: id });
       });
     }
 
@@ -363,6 +411,22 @@ import ParameterPanel from '../components/ParameterPanel.astro';
       
       // Start animation loop
       drawWaveform();
+    }
+
+    function populateMidiDevices() {
+      if (!midiController) return;
+      const select = document.getElementById('midi-device-select') as HTMLSelectElement | null;
+      if (!select) return;
+      select.innerHTML = '';
+      const inputs = midiController.getInputs();
+      inputs.forEach(input => {
+        const opt = document.createElement('option');
+        opt.value = input.id;
+        opt.textContent = input.name || input.id;
+        select.appendChild(opt);
+      });
+      const current = echoplexEngine.getState().settings.midiDeviceId;
+      if (current) select.value = current;
     }
 
     function updateUIState() {


### PR DESCRIPTION
## Summary
- extend types with MIDI settings
- update audio engine defaults and tempo handling
- implement MidiController for MIDI note, CC, and clock handling
- expose MIDI/clock settings in ParameterPanel
- wire up MIDI features in index page
- extend syncToExternalClock to use MidiController

## Testing
- `npm run build` *(fails: astro not found)*