### PR TITLE
Add mic monitor property to preset validation

### DIFF
--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -93,6 +93,7 @@ export class EchoplexAudioEngine {
       samplerStyle: 'PLAY',
       cycleBeats: 8,
       tempo: 120,
+      micMonitor: 'RECORDING_ONLY',
       feedback: 0.5,
       inputGain: 0.8,
       outputGain: 0.8,
@@ -697,6 +698,12 @@ export class EchoplexAudioEngine {
     
     if (settings.mix !== undefined) {
       this.mixer.fade.value = settings.mix;
+    }
+
+    // Future implementation could route microphone monitoring
+    if (settings.micMonitor !== undefined) {
+      // Currently we simply store the value in state
+      this.state.settings.micMonitor = settings.micMonitor;
     }
     
     console.log('Settings updated:', settings);

--- a/src/lib/preset-manager.ts
+++ b/src/lib/preset-manager.ts
@@ -96,8 +96,19 @@ export class PresetManager {
   private validateSettings(settings: any): boolean {
     // Check for required properties
     const requiredProps = [
-      'quantize', 'switchQuant', 'insertMode', 'overdubMode', 
-      'interfaceMode', 'samplerStyle', 'cycleBeats', 'tempo'
+      'quantize',
+      'switchQuant',
+      'insertMode',
+      'overdubMode',
+      'interfaceMode',
+      'samplerStyle',
+      'cycleBeats',
+      'tempo',
+      'micMonitor',
+      'feedback',
+      'inputGain',
+      'outputGain',
+      'mix'
     ];
     
     for (const prop of requiredProps) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,12 @@ export interface LoopSettings {
   samplerStyle: 'PLAY' | 'START' | 'ONCE' | 'ATTACK' | 'RUN';
   cycleBeats: number;
   tempo: number;
+  /**
+   * Microphone monitoring mode. "RECORDING_ONLY" mirrors the classic hardware
+   * behaviour where monitoring is only active while recording or overdubbing.
+   * "ALWAYS_ON" keeps the microphone routed to the output at all times.
+   */
+  micMonitor: 'RECORDING_ONLY' | 'ALWAYS_ON';
   feedback: number;
   inputGain: number;
   outputGain: number;


### PR DESCRIPTION
## Summary
- require `micMonitor` and gain-related properties in `PresetManager.validateSettings`
- define new `micMonitor` option in `LoopSettings`
- set default `micMonitor` value and persist it via `updateSettings`

## Testing
- `npm run build` *(fails: astro not found)*