### PR TITLE
Add Jest setup with basic tests

### DIFF
--- a/__mocks__/tone.ts
+++ b/__mocks__/tone.ts
@@ -1,0 +1,45 @@
+export class Player {
+  start = jest.fn();
+  stop = jest.fn();
+  connect = jest.fn();
+  dispose = jest.fn();
+}
+export class Recorder {
+  start = jest.fn();
+  stop = jest.fn();
+  connect = jest.fn();
+  dispose = jest.fn();
+}
+export class FeedbackDelay {
+  feedback = { value: 0 };
+  constructor() {}
+  connect() { return this; }
+  dispose() {}
+}
+export class Gain {
+  gain = { value: 0 };
+  constructor() {}
+  toDestination() { return this; }
+  connect() {}
+  dispose() {}
+}
+export class CrossFade {
+  a = {};
+  b = {};
+  fade = { value: 0 };
+  constructor() {}
+  connect() { return this; }
+  dispose() {}
+}
+export class Analyser {
+  constructor() {}
+  connect() {}
+  dispose() {}
+  getValue() { return new Float32Array(); }
+}
+export class UserMedia {
+  open = jest.fn().mockResolvedValue(undefined);
+  connect = jest.fn();
+  close = jest.fn();
+}
+export function setContext(){}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true
+    }
+  }
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,16 @@
+class AudioContextMock {
+  close() {}
+}
+class OfflineAudioContextMock extends AudioContextMock {}
+global.AudioContext = AudioContextMock;
+global.OfflineAudioContext = OfflineAudioContextMock;
+
+global.localStorage = (function(){
+  let store = {};
+  return {
+    getItem(key){ return store[key] || null; },
+    setItem(key,val){ store[key]=String(val); },
+    removeItem(key){ delete store[key]; },
+    clear(){ store = {}; }
+  };
+})();

--- a/package.json
+++ b/package.json
@@ -7,11 +7,16 @@
     "start": "serve dist -p $PORT",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "jest"
   },
   "dependencies": {
     "astro": "^5.7.14",
     "serve": "^14.2.1",
     "tone": "^14.7.77"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/lib/__tests__/audio-engine.test.ts
+++ b/src/lib/__tests__/audio-engine.test.ts
@@ -1,0 +1,18 @@
+import { EchoplexAudioEngine } from '../audio-engine';
+import { jest } from '@jest/globals';
+jest.mock("tone");
+import 'tone';
+
+describe('EchoplexAudioEngine basic operations', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('construct, updateSettings and dispose without errors', () => {
+    const engine = new EchoplexAudioEngine();
+    expect(() => engine.updateSettings({ tempo: 100 })).not.toThrow();
+    const state = engine.getState();
+    expect(state.settings.tempo).toBe(100);
+    expect(() => engine.dispose()).not.toThrow();
+  });
+});

--- a/src/lib/__tests__/preset-manager.test.ts
+++ b/src/lib/__tests__/preset-manager.test.ts
@@ -1,0 +1,26 @@
+import { EchoplexAudioEngine } from '../audio-engine';
+import { PresetManager } from '../preset-manager';
+jest.mock("tone");
+import { jest } from '@jest/globals';
+import 'tone';
+
+describe('PresetManager basic operations', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+  });
+
+  test('save and load preset without errors', () => {
+    const engine = new EchoplexAudioEngine();
+    const manager = new PresetManager(engine);
+
+    expect(() => manager.savePreset(1)).not.toThrow();
+    expect(localStorage.getItem('digital-echoplex-preset-1')).not.toBeNull();
+
+    const spy = jest.spyOn(engine, 'updateSettings');
+    expect(() => manager.loadPreset(1)).not.toThrow();
+    expect(spy).toHaveBeenCalled();
+
+    engine.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- install jest and ts-jest for unit testing
- configure Jest for ESM
- provide a simple WebAudio and localStorage setup for tests
- stub Tone.js for testing
- add initial tests for EchoplexAudioEngine and PresetManager

## Testing
- `npm test` *(fails: jest not found since dependencies can't be installed in this environment)*