### PR TITLE
Add start/stop insert & replace functions

### DIFF
--- a/src/lib/advanced-functions.ts
+++ b/src/lib/advanced-functions.ts
@@ -198,10 +198,38 @@ export class AdvancedLooperFunctions {
   }
 
   /**
+   * Start insert recording
+   */
+  async startInsert(): Promise<void> {
+    await this.audioEngine.startInsert();
+  }
+
+  /**
+   * Stop insert recording
+   */
+  async stopInsert(): Promise<void> {
+    await this.audioEngine.stopInsert();
+  }
+
+  /**
    * Wrapper for replace recording
    */
   async replaceLoop(): Promise<void> {
     await this.audioEngine.replaceLoop();
+  }
+
+  /**
+   * Start replace recording
+   */
+  async startReplace(): Promise<void> {
+    await this.audioEngine.startReplace();
+  }
+
+  /**
+   * Stop replace recording
+   */
+  async stopReplace(): Promise<void> {
+    await this.audioEngine.stopReplace();
   }
 
   /**

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -250,21 +250,35 @@ import ParameterPanel from '../components/ParameterPanel.astro';
         updateUIState();
       });
 
-      // Insert button
-      document.getElementById('insert-button')?.addEventListener('click', async () => {
-        if (!echoplexEngine) return;
+      // Insert button - press and hold to record
+      const insertBtn = document.getElementById('insert-button');
+      if (insertBtn) {
+        insertBtn.addEventListener('mousedown', async () => {
+          if (!echoplexEngine) return;
+          await echoplexEngine.startInsert();
+          updateUIState();
+        });
+        insertBtn.addEventListener('mouseup', async () => {
+          if (!echoplexEngine) return;
+          await echoplexEngine.stopInsert();
+          updateUIState();
+        });
+      }
 
-        await echoplexEngine.insertLoop();
-        updateUIState();
-      });
-
-      // Replace button
-      document.getElementById('replace-button')?.addEventListener('click', async () => {
-        if (!echoplexEngine) return;
-
-        await echoplexEngine.replaceLoop();
-        updateUIState();
-      });
+      // Replace button - press and hold to record
+      const replaceBtn = document.getElementById('replace-button');
+      if (replaceBtn) {
+        replaceBtn.addEventListener('mousedown', async () => {
+          if (!echoplexEngine) return;
+          await echoplexEngine.startReplace();
+          updateUIState();
+        });
+        replaceBtn.addEventListener('mouseup', async () => {
+          if (!echoplexEngine) return;
+          await echoplexEngine.stopReplace();
+          updateUIState();
+        });
+      }
     }
 
     function setupParameterControls() {
@@ -481,13 +495,13 @@ import ParameterPanel from '../components/ParameterPanel.astro';
       const insertButton = document.getElementById('insert-button');
       if (insertButton) {
         insertButton.classList.toggle('active', state.isInserting);
-        insertButton.textContent = state.isInserting ? 'Stop Insert' : 'Insert';
+        insertButton.textContent = state.isInserting ? 'Inserting...' : 'Insert';
       }
 
       const replaceButton = document.getElementById('replace-button');
       if (replaceButton) {
         replaceButton.classList.toggle('active', state.isReplacing);
-        replaceButton.textContent = state.isReplacing ? 'Stop Replace' : 'Replace';
+        replaceButton.textContent = state.isReplacing ? 'Replacing...' : 'Replace';
       }
       
       // Update loop selector


### PR DESCRIPTION
## Summary
- expand audio engine with start/stop insert and replace helpers
- expose the new helpers in `AdvancedLooperFunctions`
- allow insert/replace buttons to use press-and-hold behaviour
- show active state during sustained recording

## Testing
- `npm test` *(fails: jest not found)*